### PR TITLE
Remove unnecessary "unloadable" method

### DIFF
--- a/app/controllers/view_customizes_controller.rb
+++ b/app/controllers/view_customizes_controller.rb
@@ -1,6 +1,4 @@
 class ViewCustomizesController < ApplicationController
-  unloadable
-
   layout 'admin'
 
   before_action :require_admin

--- a/app/models/view_customize.rb
+++ b/app/models/view_customize.rb
@@ -1,6 +1,4 @@
 class ViewCustomize < ActiveRecord::Base
-  unloadable
-
   belongs_to :author, :class_name => 'User', :foreign_key => 'author_id'
 
   validates_presence_of :path_pattern


### PR DESCRIPTION
Running this plugin in development mode will raise exceptions when Rails needs to reload the changed code.
```
Unable to autoload constant ViewCustomize, expected /xxx/xxx/xxx/redmine/plugins/view_customize/app/models/view_customize.rb to define it

```

The same problem was reported in [Official redmine](http://www.redmine.org/issues/20513).
The unloadable method has already been removed from the Redmine plugin template.

Is there any chance you could remove the unloadable method?