### PR TITLE
add "Html" customize type

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 ## 機能
 
-条件に一致した画面に対して、JavaScript、CSSを埋め込むことで、画面をカスタマイズします。
+条件に一致した画面に対して、JavaScript、CSS、HTMLを埋め込むことで、画面をカスタマイズします。
 
 ## インストール方法
 
@@ -50,7 +50,7 @@ bundle exec rake redmine:plugins:migrate RAILS_ENV=production
 
 該当ページにコードの挿入位置に該当する箇所が無かった場合、コードは埋め込まれません。たとえば、「Path pattern」で`.*`で全ページを指定しても、「Insertion position」に「Bottom of issue detail」を指定していると、チケットの詳細表示画面でしか実行されないことになります。
 
-「Type」にてコードの種類(「JavaScript」または「CSS」)を選択し、「Code」に実際のコードを入力します。
+「Type」にてコードの種類(「JavaScript」、「CSS」または「HTML」)を選択し、「Code」に実際のコードを入力します。
 
 「Comment」にはカスタマイズに対する概要を記載できます。ここで入力した内容は、一覧表示で表示されます。(Commentが入力されていればComment、Commentが入力されていない場合はCodeが一覧に表示)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This a plugin allows you to customize the view for the [Redmine](http://www.redm
 
 ## Features
 
-Customize the page by inserting JavaScript or CSS on the page that matched the condition.
+Customize the page by inserting JavaScript, CSS or HTML on the page that matched the condition.
 
 ## Installation
 
@@ -53,7 +53,7 @@ Issue input fields are reconstructed when trackers or statuses are changed. If "
 If there is no part corresponding to the insertion position of the code on the page, the code is not insert.
 For example, even if you specify `.*` in "Path pattern", if "Bottom of issue detail" is specified for "Insertion position", it will be executed only on the issue detail page.
 
-In "Type", select the type of code ("JavaScript" or "CSS") and enter the actual code in "Code".
+In "Type", select the type of code ("JavaScript", "CSS" or "HTML") and enter the actual code in "Code".
 
 For "Comment" you can put an overview on customization. The contents entered here are displayed in the list display.
 When "Comment" is entered, "Comment" is displayed on the list.

--- a/app/models/view_customize.rb
+++ b/app/models/view_customize.rb
@@ -10,10 +10,12 @@ class ViewCustomize < ActiveRecord::Base
 
   TYPE_JAVASCRIPT = "javascript"
   TYPE_CSS = "css"
+  TYPE_HTML = "html"
 
   @@customize_types = {
     :label_javascript => TYPE_JAVASCRIPT,
-    :label_css => TYPE_CSS
+    :label_css => TYPE_CSS,
+    :label_html => TYPE_HTML
   }
 
   INSERTION_POSITION_HTML_HEAD = "html_head"
@@ -48,6 +50,10 @@ class ViewCustomize < ActiveRecord::Base
 
   def is_css?
     customize_type == TYPE_CSS
+  end
+
+  def is_html?
+    customize_type == TYPE_HTML
   end
 
   def available?(user=User.current)

--- a/app/views/view_customizes/show.html.erb
+++ b/app/views/view_customizes/show.html.erb
@@ -28,7 +28,7 @@
   <tr>
     <th><%=h l(:field_code) %></th>
     <td><div><%= highlight_by_language(
-	    @view_customize.code, @view_customize.customize_type) %></div></td>
+	    @view_customize.code, @view_customize.customize_type.to_sym) %></div></td>
   </tr>
   <tr>
     <th><%=h l(:field_comments) %></th>

--- a/app/views/view_customizes/show.html.erb
+++ b/app/views/view_customizes/show.html.erb
@@ -28,7 +28,7 @@
   <tr>
     <th><%=h l(:field_code) %></th>
     <td><div><%= highlight_by_language(
-	    @view_customize.code, @view_customize.is_javascript? ? :js : :css) %></div></td>
+	    @view_customize.code, @view_customize.customize_type) %></div></td>
   </tr>
   <tr>
     <th><%=h l(:field_comments) %></th>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   label_view_customizes_new: "New view customize"
   label_javascript: "JavaScript"
   label_css: "CSS"
+  label_html: "HTML"
   label_insertion_position_html_head: "Head of all pages"
   label_insertion_position_issue_form: "Bottom of issue form"
   label_insertion_position_issue_show: "Bottom of issue detail"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
   label_view_customizes_new: "新しい表示のカスタマイズ"
   label_javascript: "JavaScript"
   label_css: "CSS"
+  label_html: "HTML"
   label_insertion_position_html_head: "全てのページのヘッダ"
   label_insertion_position_issue_form: "チケット入力欄の下"
   label_insertion_position_issue_show: "チケット詳細の下"

--- a/lib/view_customize/view_hook.rb
+++ b/lib/view_customize/view_hook.rb
@@ -63,6 +63,8 @@ module RedmineViewCustomize
         html << "<style type=\"text/css\">\n"
         html << view_customize.code
         html << "\n</style>"
+      elsif view_customize.is_html?
+        html << view_customize.code
       end
 
       return html


### PR DESCRIPTION
This PR introduce a new "HTML" customize type to get more easy-to-use.

For example, when you get a "view customize" that only needs to load simple external JavaScript / CSS resources, you need to write code as follows:
```
$(document.createElement("script")).attr({
  type: "application/javascript",
  src: "https://some.cdn.example.com/path/to/javascript.js",
  defer: "defer",
  async: "async"
}).appendTo("head");
```

With a new HTML customization type, you just need to write as follows:
```
<script type="application/javascript" src="https://some.cdn.example.com/path/to/javascript.js" defer async></script>
```

Thank you for your great works of redmine-view-customize!