### PR TITLE
EasyRedmine support

### DIFF
--- a/after_init.rb
+++ b/after_init.rb
@@ -1,0 +1,1 @@
+require_dependency 'view_customize/view_hook'

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,3 @@
-require_dependency 'view_customize/view_hook'
-
 Redmine::Plugin.register :view_customize do
   requires_redmine :version_or_higher => '3.1.0'
   name 'View Customize plugin'
@@ -14,5 +12,10 @@ Redmine::Plugin.register :view_customize do
     :caption => :label_view_customize,
     :html => { :class => 'icon icon-view_customize'},
     :if => Proc.new { User.current.admin? }
+    
+  should_be_disabled false if Redmine::Plugin.installed?(:easy_extensions)
+end
 
+unless Redmine::Plugin.installed?(:easy_extensions)
+  require_relative 'after_init'
 end


### PR DESCRIPTION
This adds support for using this plugin with EasyRedmine (right now it fails on first line in init.rb).
Changes were made based on [their description](https://web.archive.org/web/20170711053111/https://www.easyredmine.com/resources/redmine-enhancements-by-easy/other-redmine-plugins) and [another plugin](https://github.com/mikitex70/redmine_drawio/blob/master/init.rb) that has support for EasyRedmine.

It probably shouldn't break regular redmine support but I don't have a way to test this. 