### PR TITLE
Add project custom field to ViewCustomize context

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -110,6 +110,9 @@ ViewCustomize = {
       "name": "Project A",
       "roles": [
         {"id": 6, "name": "RoleX"}
+      ],
+      "customFields": [
+        {"id": 4, "name": "[Project Custom field] Text", "value": "text"},
       ]
     },
     "issue": {

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ ViewCustomize = {
       "name": "Project A",
       "roles": [
         {"id": 6, "name": "RoleX"}
+      ],
+      "customFields": [
+        {"id": 4, "name": "[Project Custom field] Text", "value": "text"},
       ]
     },
     "issue": {

--- a/lib/view_customize/view_hook.rb
+++ b/lib/view_customize/view_hook.rb
@@ -91,7 +91,8 @@ module RedmineViewCustomize
         context["project"] = {
           "identifier" => project.identifier,
           "name" => project.name,
-          "roles" => user.roles_for_project(project).map {|role| { "id" => role.id, "name" => role.name }}
+          "roles" => user.roles_for_project(project).map {|role| { "id" => role.id, "name" => role.name }},
+          "customFields" => project.custom_field_values.map {|field| { "id" => field.custom_field.id, "name" => field.custom_field.name, "value" => field.value }}
         }
       end
 


### PR DESCRIPTION
REST APIを利用してプロジェクトのカスタムフィールドが取得できることは把握しておりますが、
ユーザのAPIトークン発行が必須であったり、
APIが無効なRedmineでは利用できないため、
ViewCustomize.contextから取得できるとありがたいです。