### PR TITLE
Add user's last_login_on time to ViewCustomize context

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -95,6 +95,7 @@ ViewCustomize = {
       "admin": true,
       "firstname": "Redmine",
       "lastname": "Admin",
+      "last_login_on": "2019-09-22T14:44:53Z",
       "groups": [
         {"id": 5, "name": "Group1"}
       ],

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ ViewCustomize = {
       "admin": true,
       "firstname": "Redmine",
       "lastname": "Admin",
+      "last_login_on": "2019-09-22T14:44:53Z",
       "groups": [
         {"id": 5, "name": "Group1"}
       ],

--- a/lib/view_customize/view_hook.rb
+++ b/lib/view_customize/view_hook.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module RedmineViewCustomize
   class ViewHook < Redmine::Hook::ViewListener
     def view_layouts_base_html_head(context={})
@@ -82,6 +84,7 @@ module RedmineViewCustomize
           "admin" => user.admin?,
           "firstname" => user.firstname,
           "lastname" => user.lastname,
+          "last_login_on" => (user.last_login_on.iso8601 unless user.last_login_on.nil?),
           "groups" => user.groups.map {|group| { "id" => group.id, "name" => group.name }},
           "apiKey" => (user.api_token.value unless user.api_token.nil?),
           "customFields" => user.custom_field_values.map {|field| { "id" => field.custom_field.id, "name" => field.custom_field.name, "value" => field.value }}


### PR DESCRIPTION
This adds `user.last_login_on` in ISO8601 format as `ViewCustomize.user.last_login_on`.

I am not sure this is useful for others, but I'd like to use it as a workaround of the following issue.
[Defect #24906: Session expiration not visible when editing issues - Redmine](https://www.redmine.org/issues/24906)

(Displaying alert if login time is more than some threshold past before the current time. There may be better way to do this though...)

I hope it is OK to include the change.

P.S. View customize is the most useful Redmine plugin, thanks!