### PR TITLE
Extend ViewCustomize.context with issue and tracker info

### DIFF
--- a/lib/view_customize/view_hook.rb
+++ b/lib/view_customize/view_hook.rb
@@ -27,13 +27,24 @@ module RedmineViewCustomize
 
     def view_issues_show_details_bottom(context={})
 
+      issue = context[:issue]
+      tracker = issue.tracker
+
       html =  "\n<script type=\"text/javascript\">\n//<![CDATA[\n"
-      html << "ViewCustomize.context.issue = { id: #{context[:issue].id} };"
+      html << "ViewCustomize.context.issue = {"\
+                "id: #{issue.id},"\
+                "subject: '#{issue.subject}',"\
+                "tracker: {"\
+                  "id: #{tracker.id},"\
+                  "name: '#{tracker.name}',"\
+                  "description: '#{tracker.description}'"\
+                "}"\
+              "};"
       html << "\n//]]>\n</script>\n"
 
       html << create_view_customize_html(context, ViewCustomize::INSERTION_POSITION_ISSUE_SHOW)
-
       return html
+
     end
 
     private

--- a/lib/view_customize/view_hook.rb
+++ b/lib/view_customize/view_hook.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'json'
 
 module RedmineViewCustomize
   class ViewHook < Redmine::Hook::ViewListener
@@ -31,15 +32,9 @@ module RedmineViewCustomize
       tracker = issue.tracker
 
       html =  "\n<script type=\"text/javascript\">\n//<![CDATA[\n"
-      html << "ViewCustomize.context.issue = {"\
-                "id: #{issue.id},"\
-                "subject: '#{issue.subject}',"\
-                "tracker: {"\
-                  "id: #{tracker.id},"\
-                  "name: '#{tracker.name}',"\
-                  "description: '#{tracker.description}'"\
-                "}"\
-              "};"
+      html << "ViewCustomize.context.issue = #{issue.to_json};"
+      html << "ViewCustomize.context.issue.tracker = #{tracker.to_json};"
+      html << "ViewCustomize.context.issue.tracker.customFields = #{tracker.custom_fields.to_json};"
       html << "\n//]]>\n</script>\n"
 
       html << create_view_customize_html(context, ViewCustomize::INSERTION_POSITION_ISSUE_SHOW)


### PR DESCRIPTION
While working on custom JavaScript, I found that the **ViewCustomize.context** lacked information about the issue and its tracker; my small addition extends it with all the information about the **issue**, its **tracker**, and the **custom fields** of said tracker.

Moreover, ViewCustomize.context.issue is now filled using json strings instead of string interpolation in order to provide **more extensive data** with **less code**.