### PR TITLE
Fix problem with view_customize/view_hook not loading caused by Zeitwerk support

### DIFF
--- a/after_init.rb
+++ b/after_init.rb
@@ -1,1 +1,1 @@
-require_dependency 'view_customize/view_hook'
+require File.expand_path('../lib/view_customize/view_hook', __FILE__)


### PR DESCRIPTION
I think the problem with #84 will be solved by this change.
Changed the way to write the path passed to require.