### PR TITLE
Fixes the migration 008 is irreversible

### DIFF
--- a/db/migrate/008_change_default_bugfix_on_view_customizes.rb
+++ b/db/migrate/008_change_default_bugfix_on_view_customizes.rb
@@ -1,6 +1,10 @@
 class ChangeDefaultBugfixOnViewCustomizes < ActiveRecord::CompatibleLegacyMigration.migration_class
-  def change
+  def up
     change_column_default :view_customizes, :path_pattern, ""
     change_column_default :view_customizes, :comments, ""
+  end
+
+  def down
+    # Leave the default values unchanged
   end
 end


### PR DESCRIPTION
You can not reverse migrations of the plugin due to migration 008.

```
$ bin/rake redmine:plugins:migrate NAME=view_customize VERSION=0
== 8 ChangeDefaultBugfixOnViewCustomizes: reverting ===========================
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:



change_column_default is only reversible if given a :from and :to option.

(...snip...)

Caused by:
ActiveRecord::IrreversibleMigration: 

change_column_default is only reversible if given a :from and :to option.

```