### PR TITLE
A simple solution to add custom code at the bottom of context menu.

### DIFF
--- a/app/models/view_customize.rb
+++ b/app/models/view_customize.rb
@@ -22,12 +22,14 @@ class ViewCustomize < ActiveRecord::Base
   INSERTION_POSITION_HTML_BOTTOM = "html_bottom"
   INSERTION_POSITION_ISSUE_FORM = "issue_form"
   INSERTION_POSITION_ISSUE_SHOW = "issue_show"
+  INSERTION_POSITION_CONTEXT_MENU_END = "context_menu_end"
 
   @@insertion_positions = {
     :label_insertion_position_html_head => INSERTION_POSITION_HTML_HEAD,
     :label_insertion_position_issue_form => INSERTION_POSITION_ISSUE_FORM,
     :label_insertion_position_issue_show => INSERTION_POSITION_ISSUE_SHOW,
-    :label_insertion_position_html_bottom => INSERTION_POSITION_HTML_BOTTOM
+    :label_insertion_position_html_bottom => INSERTION_POSITION_HTML_BOTTOM,
+    :label_insertion_position_context_menu_end => INSERTION_POSITION_CONTEXT_MENU_END
   }
 
   def customize_types

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
   label_insertion_position_html_bottom: "Bottom of all pages"
   label_insertion_position_issue_form: "Bottom of issue form"
   label_insertion_position_issue_show: "Bottom of issue detail"
+  label_insertion_position_context_menu_end: "End of context menu"
   field_path_pattern: "Path pattern"
   field_project_pattern: "Project pattern"
   field_insertion_position: "Insertion position"

--- a/lib/redmine_view_customize/view_hook.rb
+++ b/lib/redmine_view_customize/view_hook.rb
@@ -50,6 +50,10 @@ module RedmineViewCustomize
 
       return html
     end
+    
+    def view_issues_context_menu_end(context={})
+      return "\n" + create_view_customize_html(context, ViewCustomize::INSERTION_POSITION_CONTEXT_MENU_END)
+    end 
 
     private
 


### PR DESCRIPTION
We had to lock out some items in the context menu based on user groups and project ids so we decided to enable this option in our view customize instance instead of hacking with server-side code.