### PR TITLE
Prevents XSS injection through wrong url path

### DIFF
--- a/lib/redmine_view_customize/view_hook.rb
+++ b/lib/redmine_view_customize/view_hook.rb
@@ -3,7 +3,7 @@ require 'time'
 module RedmineViewCustomize
   class ViewHook < Redmine::Hook::ViewListener
     def view_layouts_base_html_head(context={})
-      path = Redmine::CodesetUtil.replace_invalid_utf8(context[:request].path_info);
+      path = sanitize(Redmine::CodesetUtil.replace_invalid_utf8(context[:request].path_info));
 
       html = "\n<!-- [view customize plugin] path:#{path} -->\n"
       html << stylesheet_link_tag("view_customize", plugin: "view_customize")


### PR DESCRIPTION
Hi,

here is a tiny patch against XSS injection thanks of URL.

We had a security report about this.

Without the patch you can close commentary brackets in the url and run JS scripts adding in url

Example of bad hacker URL (only add text : xss visible in source code)
https://www.myredmine.com/projects/myproject--%3E%3Ch1%3Exss%3C!--/issues