### PR TITLE
ChromeDriver installation fails in CircleCI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         default: redmine
       ruby_version:
         type: string
-        default: "3.3" # https://github.com/redmine/redmine/blob/5.1.0/Gemfile#L3
+        default: "3.2" # https://github.com/redmine/redmine/blob/5.1.0/Gemfile#L3
       database:
         type: enum
         enum:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   redmine-plugin: agileware-jp/redmine-plugin@3.3.1
+  browser-tools: circleci/browser-tools@1.4.6
 
 jobs:
   run_tests:
@@ -50,6 +51,8 @@ jobs:
       - run:
           working_directory: redmine
           command: touch Gemfile.local
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - redmine-plugin/bundle-install
       - redmine-plugin/test:
           plugin: view_customize


### PR DESCRIPTION
It seems that the version of circleci/browser-tools used in redmine-plugin/bundle-install is out of date, so the installation of ChromeDirver for the new Chrome fails.

The following version of Chrome failed.

* 116.0.5845.140

The following version of Chrome succeeds.

* 112.0.5615.49

I work around this by installing ChromeDirver beforehand using the latest version of circleci/browser-tools.