### PR TITLE
limit custom fields to defined user visibility

### DIFF
--- a/lib/redmine_view_customize/view_hook.rb
+++ b/lib/redmine_view_customize/view_hook.rb
@@ -141,7 +141,8 @@ module RedmineViewCustomize
           "identifier" => project.identifier,
           "name" => project.name,
           "roles" => user.roles_for_project(project).map {|role| { "id" => role.id, "name" => role.name }},
-          "customFields" => project.custom_field_values.map {|field| { "id" => field.custom_field.id, "name" => field.custom_field.name, "value" => field.value }}
+          # Only include custom field values which are visible to the current user
+          "customFields" => project.visible_custom_field_values().map {|field| { "id" => field.custom_field.id, "name" => field.custom_field.name, "value" => field.value }}
         }
       end
 


### PR DESCRIPTION
fix for issue #119 
`ViewCustomize.context.project.customFields` previously contained all custom fields, even if the user has no access to them.

Fixed by using `project.visible_custom_field_values()` function instead of raw structure `project.custom_field_values`.