### PR TITLE
Adapt to base class changes in Redmine models

### DIFF
--- a/app/models/view_customize.rb
+++ b/app/models/view_customize.rb
@@ -1,4 +1,4 @@
-class ViewCustomize < ActiveRecord::Base
+class ViewCustomize < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   belongs_to :author, :class_name => 'User', :foreign_key => 'author_id'
 
   validates_length_of :path_pattern, :maximum => 255


### PR DESCRIPTION
## Motivation / Background

Due to changes in [Redmine issue #38975](https://www.redmine.org/issues/38975), the base class for models in Redmine has been changed from `ActiveRecord::Base` to `ApplicationRecord`. Currently, this change is included in the roadmap for Redmine 6.

This plugin does not use methods such as [acts_as_positioned](https://github.com/redmine/redmine/blob/e4fcfc6990a724cacd6d4e978ee051735769f180/lib/redmine/preparation.rb#L23) which Redmine adds to `ApplicationRecord`, so it is unlikely unaffected by this change. In fact, I have verified that the plugin operates correctly with Redmine trunk(r22787).

However, since Redmine has overriden and modified the `human_attribute_name` method in `ApplicationRecord` ([code](https://github.com/redmine/redmine/blob/1c17ae733dfa0216fb6427722d2a479413369e87/app/models/application_record.rb)) , continuing to inherit from `ActiveRecord::Base` may alter the behavior of this method. Furthermore, this would prevent following any future changes or additions to `ApplicationRecord`.

For more detailed information about this change, you might find the following article helpful (In Japanese):
https://blog.redmine.jp/articles/6_0/checklist-themes-plugins-developer-before-redmine-6/

## Detail

Given the above, this pull request proposes modifying the inheritance for the `ViewCustomize` model to support both `ApplicationRecord` and `ActiveRecord::Base`. This change will maintain compatibility with Redmine 5 while facilitating a transition to Redmine 6.

## Additional Information

I have manually confirmed the ability to insert HTML into the header section in the following environments:

* Redmine trunk (r22787) + Ruby 3.3.0
* Redmine v5.1 + Ruby 3.2.3
