### PR TITLE
Remove unnecessary icon styles

### DIFF
--- a/assets/stylesheets/view_customize.css
+++ b/assets/stylesheets/view_customize.css
@@ -69,10 +69,3 @@ input#view_customize_comments {
 .icon-view_customize-enable:not(:has(svg)) {
     background-image: url("../images/enable.png");
 }
-
-/* PNG icon support for Redmine 5.1 and earlier */
-.icon:not(:has(svg)) {
-  background-position: 0% 50%;
-  background-repeat: no-repeat;
-  padding-left: 20px;
-}


### PR DESCRIPTION
## Background / Purpose

This PR removes the following icon style added in [#128](https://github.com/onozaty/redmine-view-customize/pull/128), which turned out to be actually unnecessary:
https://github.com/onozaty/redmine-view-customize/blob/dfee75df6e063ab3e08b0dfbb3613d7bc4c03c18/assets/stylesheets/view_customize.css#L73-L78

## Details

Up to Redmine 6.1, the same style has already been defined in Redmine core, so there is no need for this plugin to define the `.icon` style.
Keeping this style globally in the plugin might even cause unexpected UI issues in the future.

## Checks

Confirmed that icons are displayed correctly from Redmine 5.1 through trunk (r24062).

### 5.1

<details><summary>Details</summary>
<p>

<img width="995" height="582" alt="5 1-1" src="https://github.com/user-attachments/assets/76e6b5ad-8f59-4304-bd1c-36feaaff09ed" />

<img width="995" height="582" alt="5 1-2" src="https://github.com/user-attachments/assets/fe7e98e5-5919-491e-88df-13a50179c755" />

</p>
</details> 

### 6.0

<details><summary>Details</summary>
<p>

<img width="996" height="588" alt="6 0-1" src="https://github.com/user-attachments/assets/eefe9365-68fc-4943-9ca7-3f572166dd77" />

<img width="996" height="588" alt="6 0-2" src="https://github.com/user-attachments/assets/0f0fa529-bf40-47c8-8eae-805283801c94" />

</p>
</details> 

### trunk(r24062)

<details><summary>Details</summary>
<p>

<img width="996" height="588" alt="trunk-1" src="https://github.com/user-attachments/assets/57309d69-9165-4a6a-a345-9bef42aa5f40" />

<img width="996" height="588" alt="trunk-2" src="https://github.com/user-attachments/assets/9343c170-b590-47ae-8bb7-7400d94c057d" />


</p>
</details> 