### PR TITLE
chore: update DevContainer configuration

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "redmine",
   "remoteUser": "redmine",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./database.yml:/usr/src/redmine/config/database.yml
       - ./..:/usr/src/redmine/plugins/view_customize
   db:
-    image: postgres:latest
+    image: postgres:17
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
## Summary
- Add GitHub CLI feature to DevContainer
- Pin postgres image to version 17 instead of latest

## Test plan
- [x] Rebuild DevContainer and confirm it starts successfully
- [x] Confirm `gh` command is available inside the container
- [x] Confirm postgres 17 is used and the app connects successfully