### PR TITLE
feat: add redmine-4.1 CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,3 +97,8 @@ workflows:
           redmine_version: "4.2"
           ruby_version: "2.7" # https://github.com/redmine/redmine/blob/4.2.10/Gemfile#L3
           database: pg
+      - run_tests:
+          name: redmine-4.0 with PostgreSQL
+          redmine_version: "4.0"
+          ruby_version: "2.6" # https://github.com/redmine/redmine/blob/4.0.9/Gemfile#L3
+          database: pg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,10 @@ jobs:
           working_directory: redmine
           command: |
             set -eux -o pipefail
-            # loofah >= 2.21 requires Nokogiri::HTML4, which nokogiri ~> 1.10.0 (pinned here) doesn't have.
+            # loofah >= 2.21 requires Nokogiri::HTML4, which was introduced in nokogiri 1.12.0.
+            # Redmine 4.0/4.1 pin nokogiri to ~> 1.10.0 or ~> 1.11.1, so pin loofah too.
             # https://github.com/flavorjones/loofah/blob/v2.21.0/CHANGELOG.md
-            grep -q 'nokogiri.*~> 1.10.0' Gemfile || exit 0
+            grep -Eq "nokogiri.*~> 1\.(10|11)\." Gemfile || exit 0
             echo 'gem "loofah", "< 2.21"' >> Gemfile.local
       - redmine-plugin/bundle-install
       - redmine-plugin/test:
@@ -107,7 +108,7 @@ workflows:
           ruby_version: "2.7" # https://github.com/redmine/redmine/blob/4.2.10/Gemfile#L3
           database: pg
       - run_tests:
-          name: redmine-4.0 with PostgreSQL
-          redmine_version: "4.0"
-          ruby_version: "2.6" # https://github.com/redmine/redmine/blob/4.0.9/Gemfile#L3
+          name: redmine-4.1 with PostgreSQL
+          redmine_version: "4.1"
+          ruby_version: "2.6" # https://github.com/redmine/redmine/blob/4.1.7/Gemfile#L3
           database: pg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,15 @@ jobs:
             # https://rubygems.org/gems/commonmarker/versions/2.3.2 requires RubyGems ~> 3.4
             grep -q "gem 'commonmarker', '~> 2.3" Gemfile || exit 0
             sudo gem update --system 3.4.22
+      - run:
+          name: Pin loofah for Redmine's pinned nokogiri version
+          working_directory: redmine
+          command: |
+            set -eux -o pipefail
+            # loofah >= 2.21 requires Nokogiri::HTML4, which nokogiri ~> 1.10.0 (pinned here) doesn't have.
+            # https://github.com/flavorjones/loofah/blob/v2.21.0/CHANGELOG.md
+            grep -q 'nokogiri.*~> 1.10.0' Gemfile || exit 0
+            echo 'gem "loofah", "< 2.21"' >> Gemfile.local
       - redmine-plugin/bundle-install
       - redmine-plugin/test:
           plugin: view_customize


### PR DESCRIPTION
## Summary
- Add a CI job for Redmine 4.1 (latest patch: 4.1.7), which was untested
  - Originally targeted 4.0.9, but its issue fixture record (id: 1) doesn't set `estimated_hours` (added upstream in 4.1.7), which broke an existing plugin test unrelated to this change. Track 4.1 instead.
- Redmine 4.1's Gemfile requires Ruby `>= 2.3.0, < 2.7.0`, so use Ruby 2.6 (`cimg/ruby:2.6-browsers` is available)
- Both 4.0 and 4.1 pin nokogiri to a version that predates `Nokogiri::HTML4` (added in nokogiri 1.12.0), while loofah >= 2.21 requires it. Pin loofah to `< 2.21` when this is detected, to avoid a `NameError` at boot

## Test plan
- [x] Confirm the redmine-4.1 job passes on CircleCI